### PR TITLE
Feat: Adds event on message failure

### DIFF
--- a/src/Events/FcmMessageFailed.php
+++ b/src/Events/FcmMessageFailed.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Nylo\LaravelFCM\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+final readonly class FcmMessageFailed
+{
+    use Dispatchable;
+
+    public string $token;
+    
+    public string $errorMessage;
+
+    public function __construct(string $token, string $errorMessage)
+    {
+        $this->token = $token;
+        $this->errorMessage = $errorMessage;
+    }
+}

--- a/src/Services/FcmCloudMessagingService.php
+++ b/src/Services/FcmCloudMessagingService.php
@@ -7,7 +7,7 @@ use Kreait\Firebase\Messaging\ApnsConfig;
 use Kreait\Firebase\Messaging\CloudMessage;
 use Illuminate\Support\Facades\Log;
 use Nylo\LaravelFCM\Models\FcmMessage;
-
+use Nylo\LaravelFCM\Events\FcmMessageFailed;
 /**
  * Class FcmCloudMessagingService
  *
@@ -93,6 +93,11 @@ class FcmCloudMessagingService extends FirebaseService
         if ($report->hasFailures()) {
             foreach ($report->failures()->getItems() as $failure) {
                 Log::error('Laravel FCM Channel: ' . $failure->error()->getMessage());
+
+                event(new FcmMessageFailed(
+                    $failure->target()->value(),
+                    $failure->error()->getMessage()
+                ));
             }
         }
     }
@@ -165,6 +170,11 @@ class FcmCloudMessagingService extends FirebaseService
         if ($report->hasFailures()) {
             foreach ($report->failures()->getItems() as $failure) {
                 Log::error('Laravel FCM Channel: ' . $failure->error()->getMessage());
+
+                event(new FcmMessageFailed(
+                    $failure->target()->value(),
+                    $failure->error()->getMessage()
+                ));
             }
         }
     }


### PR DESCRIPTION
Hi! 👋

First of all, thank you for this package, I am using it actively and its good. But I've felt the need of having an event dispatched when a notification fails, mostly because the token is expired or renewed. So this PR adds the `FcmMessageFailed` event that can later be listened to like:

```php
<?php

namespace App\Listeners;

use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Queue\InteractsWithQueue;
use Illuminate\Support\Facades\Log;
use Nylo\LaravelFCM\Events\FcmMessageFailed;

class HandleFcmFailure
{
    /**
     * Create the event listener.
     */
    public function __construct()
    {
        //
    }

    /**
     * Handle the event.
     */
    public function handle(FcmMessageFailed $event): void
    {
        Log::debug($event->errorMessage);
        Log::debug($event->token);

       // Do anything here...
    }
}
```
Hope it helps!
