### PR TITLE
Fix job serialization error in `ProcessFcmNotificationsJob`

### DIFF
--- a/src/Jobs/ProcessFcmNotificationsJob.php
+++ b/src/Jobs/ProcessFcmNotificationsJob.php
@@ -10,6 +10,7 @@ use Illuminate\Queue\SerializesModels;
 use Exception;
 use Illuminate\Support\Facades\Log;
 use Nylo\LaravelFCM\Models\FcmMessage;
+use Nylo\LaravelFCM\Services\FcmCloudMessagingService;
 
 class ProcessFcmNotificationsJob implements ShouldQueue
 {
@@ -18,8 +19,6 @@ class ProcessFcmNotificationsJob implements ShouldQueue
     public $notification;
 
     public $notifiable;
-
-    public $fcmCloudMessagingService;
 
     /**
      * Create a new job instance.
@@ -34,7 +33,6 @@ class ProcessFcmNotificationsJob implements ShouldQueue
             $this->notification = $notification;
         }
         $this->notifiable = $notifiable;
-        $this->fcmCloudMessagingService = resolve('Nylo\LaravelFCM\Services\FcmCloudMessagingService');
     }
 
     /**
@@ -55,9 +53,11 @@ class ProcessFcmNotificationsJob implements ShouldQueue
             return;
         }
 
-        $fcmDevices->chunk(500, function($devices) {
+        $fcmCloudMessagingService = app(FcmCloudMessagingService::class);
+
+        $fcmDevices->chunk(500, function($devices) use ($fcmCloudMessagingService) {
             try {
-                $this->fcmCloudMessagingService->sendMessages($this->notification, $devices);
+                $fcmCloudMessagingService->sendMessages($this->notification, $devices);
             } catch (Exception $e) {
                 Log::error($e->getMessage());
             }


### PR DESCRIPTION
### Why

I started getting a `Serialization of 'Closure' is not allowed` when trying to dispatch a queued notification.

This happens because queued jobs are serialized and the service container resolution cannot be serialized.

### What

I moved the service resolution from the container to the handle method.