### PR TITLE
Add Laravel 13 and firebase-php 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,13 @@
     ],
     "require": {
         "php": ">=8.1",
-        "illuminate/support": "~5.8.0|6.x|7.x|8.x|9.x|10.x|11.x|12.x",
-        "kreait/firebase-php": "^7.12"
+        "illuminate/support": "~5.8.0|6.x|7.x|8.x|9.x|10.x|11.x|12.x|13.x",
+        "kreait/firebase-php": "^7.12|^8.0"
     },
     "require-dev": {
         "larastan/larastan": "^3.10",
         "laravel/pint": "^1.27",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "phpunit/phpunit": "^12.5.22"
     },
     "autoload": {


### PR DESCRIPTION
Widens the dependency constraints so the package can be installed on Laravel 13 and alongside `kreait/firebase-php` 8.x.

## Changes

- `illuminate/support`: allow `13.x`
- `kreait/firebase-php`: allow `^8.0` alongside `^7.12`
- `orchestra/testbench` (dev): allow `^11.0`, the release that targets Laravel 13

Note that firebase-php 8 requires PHP >= 8.3, so installs on PHP 8.1/8.2 will continue to resolve to 7.x — the `^7.12|^8.0` union keeps both paths open rather than forcing the bump.

## Testing

Verified in a production Laravel application upgraded from 12.64 to 13.23 with `kreait/firebase-php` 8.3.0 and `kreait/laravel-firebase` 7.2.1 installed: a suite of 1245 tests passes with no regressions against the pre-upgrade baseline.
